### PR TITLE
LW-30144 fix bundle error & add page view

### DIFF
--- a/src/DTO/KameleoonUserDataSet.php
+++ b/src/DTO/KameleoonUserDataSet.php
@@ -7,7 +7,7 @@ namespace Lingoda\KameleoonBundle\DTO;
 class KameleoonUserDataSet
 {
     /** @var KameleoonUserData[] */
-    private array $dataSet;
+    private array $dataSet = [];
 
     public function addData(KameleoonUserData $data): self
     {

--- a/src/Enum/KameleoonVariationKeyEnum.php
+++ b/src/Enum/KameleoonVariationKeyEnum.php
@@ -7,9 +7,26 @@ namespace Lingoda\KameleoonBundle\Enum;
 enum KameleoonVariationKeyEnum: string
 {
     case VARIANT = 'variant';
-	
+
     case CONTROL = 'control';
 
-	case OFF = 'off';
-}
+    case OFF = 'off';
 
+    case ON = 'on';
+
+    /**
+     * @return KameleoonVariationKeyEnum[]
+     */
+    public static function getVariantChoices(): array
+    {
+        return [
+            self::VARIANT,
+            self::ON,
+        ];
+    }
+
+    public static function isVariant(KameleoonVariationKeyEnum $variationKey): bool
+    {
+        return in_array($variationKey, self::getVariantChoices(), true);
+    }
+}


### PR DESCRIPTION
Fixes: 
- error during custom data applying (even without its usage) - adding default empty array
- wrong return type of getting visitor code (it's always non-nullable)
- Needs to add a page view for a kameleoon request
- add one more variation enum value (“ON”) and one enum-util (isVariant)
- fix stan error & fix spec test