### PR TITLE
LW-30295 Added checking if warmup happens with default values which will resolve in incorrectly authorised call to kameleoon causing 400 error

### DIFF
--- a/src/Cache/CacheWarmer.php
+++ b/src/Cache/CacheWarmer.php
@@ -11,6 +11,10 @@ use Symfony\Component\HttpKernel\CacheWarmer\CacheWarmerInterface;
 
 class CacheWarmer implements CacheWarmerInterface
 {
+    private const DEFAULTS = [
+        'tmp_test'
+    ];
+
     private FilesystemManager $filesystem;
 
     public function __construct(
@@ -29,7 +33,10 @@ class CacheWarmer implements CacheWarmerInterface
     public function warmUp(string $cacheDir): array
     {
         $this->warmUpWorkingDir();
-        $this->warmUpConfigFile();
+
+        if (!in_array($this->config->getConfig()->getClientId(), self::DEFAULTS, true)) {
+            $this->warmUpConfigFile();
+        }
 
         return [];
     }


### PR DESCRIPTION
This pull request includes changes to the `CacheWarmer` class in the `src/Cache/CacheWarmer.php` file. The most important changes involve the introduction of a new constant and an update to the `warmUp` method to utilize this constant.

Key changes:

* [`src/Cache/CacheWarmer.php`](diffhunk://#diff-09b59ec9a25b4bdd4e55488d818b43cb52169523334983d8e3cad451b7d0f539R14-R17): Added a new private constant `DEFAULTS` to store default values.
* [`src/Cache/CacheWarmer.php`](diffhunk://#diff-09b59ec9a25b4bdd4e55488d818b43cb52169523334983d8e3cad451b7d0f539R36-R39): Updated the `warmUp` method to check if the client ID is in the `DEFAULTS` array before calling `warmUpConfigFile`.